### PR TITLE
Force the returned solution object to stay as ODESolution

### DIFF
--- a/pyrms/rms.py
+++ b/pyrms/rms.py
@@ -23,6 +23,35 @@ def pygetfluxdiagram(bsol,t,centralspecieslist=[],superimpose=False,
 
 ReactionMechanismSimulator.getfluxdiagram = pygetfluxdiagram
 
+# These functions force the returned object to be a jlwrap object, 
+# to avoid the solution object gets converted into list of lists
+_threadedsensitivities_inds = Main.pyfunctionret(ReactionMechanismSimulator.threadedsensitivities, Main.Any, Main.PyAny, Main.PyAny)
+_threadedsensitivities = Main.pyfunctionret(ReactionMechanismSimulator.threadedsensitivities, Main.Any, Main.PyAny)
+# Allow us the get the solution object in the julia wrapped object without
+# it being converted into list of lists
+get = Main.pyfunctionret(Main.get, Main.Any, Main.PyAny, Main.PyAny, Main.PyAny)
+def pythreadedsensitivities(react, inds=None,
+                            odesolver=Main.nothing, senssolver=Main.nothing,
+                            odekwargs={"abstol": 1e-20, "reltol": 1e-6},
+                            senskwargs={"abstol": 1e-6, "reltol": 1e-3}):
+    if inds is not None:
+        # the sol_dict returned here is a jlwrap object and is not easy to access the contents
+        sol_dict = _threadedsensitivities_inds(react, inds,
+                                               odesolver=odesolver, senssolver=senssolver,
+                                               odekwargs=odekwargs, senskwargs=senskwargs)
+        # pysol_dict is the python dictionary, but the solution object got turned into list of lists
+        pysol_dict = Main.PyObject(sol_dict)
+        # this remakes the dictionary with the values as julia wrapped object ODEsolution, 
+        # but at the same time allows the user to access it normally like a dictionary
+        return {key: get(sol_dict, key, Main.Any) for key in pysol_dict.keys()}
+    else:
+        sol = _threadedsensitivities(react, 
+                                     odesolver=odesolver, senssolver=senssolver,
+                                     odekwargs=odekwargs, senskwargs=senskwargs)
+        return sol
+
+ReactionMechanismSimulator.threadedsensitivities = pythreadedsensitivities
+
 for item in dir(ReactionMechanismSimulator):
     try:
         locals()[item] = getattr(ReactionMechanismSimulator,item)


### PR DESCRIPTION
`ReactionMechanismSimulator.threadedsensitivities` is supposed to return either an ODESolution object, or a dictionary containing ODESolution as values, but they both get converted to list of lists when we use it through pyrms.

Fixing the case that returns an ODESolution object is easier, I use the solution mentioned in https://github.com/JuliaPy/PyCall.jl/issues/460.
Fixing the case that returns a dictionary of ODESolution objects is trickier. I had to force the `Main.get` to not convert the value into list of lists.