### PR TITLE
remove import rms during init

### DIFF
--- a/pyrms/__init__.py
+++ b/pyrms/__init__.py
@@ -1,1 +1,0 @@
-import rms


### PR DESCRIPTION
This throws an error during conda build and is not really needed according to the tar file of v0.1.2 of pyrms on PyPI.